### PR TITLE
Fix Keras 3 Loading Error and Standardize Model Initialization

### DIFF
--- a/4- Making Predictions with the Speech Recognition System/keyword_spotting_service.py
+++ b/4- Making Predictions with the Speech Recognition System/keyword_spotting_service.py
@@ -1,3 +1,6 @@
+import os
+# Must be set before importing tensorflow
+os.environ["TF_USE_LEGACY_KERAS"] = "1"
 import librosa
 import tensorflow as tf
 import numpy as np
@@ -80,7 +83,12 @@ def Keyword_Spotting_Service():
     # ensure an instance is created only the first time the factory function is called
     if _Keyword_Spotting_Service._instance is None:
         _Keyword_Spotting_Service._instance = _Keyword_Spotting_Service()
-        _Keyword_Spotting_Service.model = tf.keras.models.load_model(SAVED_MODEL_PATH)
+        # Explicitly setting compile=False often resolves deserialization 
+        # issues where the optimizer config has changed between Keras versions
+        _Keyword_Spotting_Service.model = tf.keras.models.load_model(
+            SAVED_MODEL_PATH, 
+            compile=False
+        )
     return _Keyword_Spotting_Service._instance
 
 

--- a/5- Deploying the Speech Recognition System as a Flask API/keyword_spotting_service.py
+++ b/5- Deploying the Speech Recognition System as a Flask API/keyword_spotting_service.py
@@ -1,3 +1,6 @@
+import os
+# Must be set before importing tensorflow
+os.environ["TF_USE_LEGACY_KERAS"] = "1"
 import librosa
 import tensorflow as tf
 import numpy as np
@@ -80,7 +83,12 @@ def Keyword_Spotting_Service():
     # ensure an instance is created only the first time the factory function is called
     if _Keyword_Spotting_Service._instance is None:
         _Keyword_Spotting_Service._instance = _Keyword_Spotting_Service()
-        _Keyword_Spotting_Service.model = tf.keras.models.load_model(SAVED_MODEL_PATH)
+        # Explicitly setting compile=False often resolves deserialization 
+        # issues where the optimizer config has changed between Keras versions
+        _Keyword_Spotting_Service.model = tf.keras.models.load_model(
+            SAVED_MODEL_PATH, 
+            compile=False
+        )
     return _Keyword_Spotting_Service._instance
 
 

--- a/6- Deploying the Speech Recognition System with uWSGI/code/keyword_spotting_service.py
+++ b/6- Deploying the Speech Recognition System with uWSGI/code/keyword_spotting_service.py
@@ -1,3 +1,6 @@
+import os
+# Must be set before importing tensorflow
+os.environ["TF_USE_LEGACY_KERAS"] = "1"
 import librosa
 import tensorflow as tf
 import numpy as np
@@ -80,7 +83,12 @@ def Keyword_Spotting_Service():
     # ensure an instance is created only the first time the factory function is called
     if _Keyword_Spotting_Service._instance is None:
         _Keyword_Spotting_Service._instance = _Keyword_Spotting_Service()
-        _Keyword_Spotting_Service.model = tf.keras.models.load_model(SAVED_MODEL_PATH)
+        # Explicitly setting compile=False often resolves deserialization 
+        # issues where the optimizer config has changed between Keras versions
+        _Keyword_Spotting_Service.model = tf.keras.models.load_model(
+            SAVED_MODEL_PATH, 
+            compile=False
+        )
     return _Keyword_Spotting_Service._instance
 
 

--- a/7- Deploying the Speech Recognition System on Docker with NGINX/code/flask/keyword_spotting_service.py
+++ b/7- Deploying the Speech Recognition System on Docker with NGINX/code/flask/keyword_spotting_service.py
@@ -1,3 +1,6 @@
+import os
+# Must be set before importing tensorflow
+os.environ["TF_USE_LEGACY_KERAS"] = "1"
 import librosa
 import tensorflow as tf
 import numpy as np
@@ -80,7 +83,12 @@ def Keyword_Spotting_Service():
     # ensure an instance is created only the first time the factory function is called
     if _Keyword_Spotting_Service._instance is None:
         _Keyword_Spotting_Service._instance = _Keyword_Spotting_Service()
-        _Keyword_Spotting_Service.model = tf.keras.models.load_model(SAVED_MODEL_PATH)
+        # Explicitly setting compile=False often resolves deserialization 
+        # issues where the optimizer config has changed between Keras versions
+        _Keyword_Spotting_Service.model = tf.keras.models.load_model(
+            SAVED_MODEL_PATH, 
+            compile=False
+        )
     return _Keyword_Spotting_Service._instance
 
 

--- a/8- Deploying on AWS/server/flask/keyword_spotting_service.py
+++ b/8- Deploying on AWS/server/flask/keyword_spotting_service.py
@@ -1,3 +1,6 @@
+import os
+# Must be set before importing tensorflow
+os.environ["TF_USE_LEGACY_KERAS"] = "1"
 import librosa
 import tensorflow as tf
 import numpy as np
@@ -80,7 +83,12 @@ def Keyword_Spotting_Service():
     # ensure an instance is created only the first time the factory function is called
     if _Keyword_Spotting_Service._instance is None:
         _Keyword_Spotting_Service._instance = _Keyword_Spotting_Service()
-        _Keyword_Spotting_Service.model = tf.keras.models.load_model(SAVED_MODEL_PATH)
+        # Explicitly setting compile=False often resolves deserialization 
+        # issues where the optimizer config has changed between Keras versions
+        _Keyword_Spotting_Service.model = tf.keras.models.load_model(
+            SAVED_MODEL_PATH, 
+            compile=False
+        )
     return _Keyword_Spotting_Service._instance
 
 


### PR DESCRIPTION
**Description**
The `keyword_spotting_service.py` script fails during model initialization in environments running **Keras 3**. This occurs because the Keras 3 deserialization engine misinterprets the 4D input shape of the legacy Sequential model, adding an extra `None` dimension that causes a structural mismatch in the convolutional layers.

**Solution**
This PR implements a dual-layer fix to ensure maximum compatibility:

1. **Forced Legacy Engine:** Sets `TF_USE_LEGACY_KERAS = "1"` before importing TensorFlow to revert to the Keras 2 saving/loading behavior.
2. **Bypass Compilation:** Sets `compile=False` within `load_model()` to prevent Keras from attempting to reconstruct the optimizer and loss functions from the legacy file, avoiding version-mismatch crashes.

**Changes**

* **Global Configuration:** Added the legacy environment variable to the top of the scripts.
* **Service Factory:** Updated the `Keyword_Spotting_Service` factory function to load the model with `compile=False`.
* **Repository-wide Fix:** Applied changes to `keyword_spotting_service.py` across Chapters 4 through 8 to ensure consistency in all deployment examples.

**Testing & Verification**

* **Loading:** Confirmed the model loads without the `ValueError` dimension mismatch.
* **Inference:** Verified that `predict()` accurately identifies keywords from audio files.
* **Singleton Integrity:** `assert kss is kss1` remains valid, ensuring only one instance of the model is held in memory.